### PR TITLE
6 total rev discounted rev

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -88,3 +88,7 @@
    display:inline-block;
    margin-left: 20px;
 }
+
+#total-discount {
+   color: red;
+}

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -7,10 +7,28 @@ class Invoice < ApplicationRecord
   has_many :invoice_items
   has_many :items, through: :invoice_items
   has_many :merchants, through: :items
+  has_many :discounts, through: :merchants
 
   enum status: [:cancelled, :in_progress, :completed]
 
   def total_revenue
     invoice_items.sum("unit_price * quantity")
+  end
+
+  
+  def total_discount
+    max_discounts = invoice_items.select("invoice_items.id, 
+      MAX(discounts.percent_discount / 100.0) 
+      * invoice_items.unit_price 
+      * invoice_items.quantity as total_discount")
+      .joins(item: { merchant: :discounts })
+      .where("discounts.threshold_quantity <= invoice_items.quantity")
+      .group("invoice_items.id")
+
+    max_discounts.sum { |invoice_item| invoice_item.total_discount }  
+  end
+    
+  def total_discounted_revenue
+    total_revenue - total_discount
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,6 +7,7 @@ class Item < ApplicationRecord
   has_many :invoice_items
   has_many :invoices, through: :invoice_items
   belongs_to :merchant
+  has_many :discounts, through: :merchant
 
   enum status: [:disabled, :enabled]
 

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -10,9 +10,12 @@
   </div>
   <br>
 
-  <p> Created on: <%= @invoice.created_at.strftime("%A, %B %-d, %Y") %></p>
-  <p>Total Revenue: <%= @invoice.total_revenue %></p>
-
+  <div id="invoice-info">
+    <p> Created on: <%= @invoice.created_at.strftime("%A, %B %-d, %Y") %></p>
+    <p>Total Revenue: <%= number_to_currency(@invoice.total_revenue) %></p>
+    <p>Total Discounts Applied: <b id="total-discount">(</b> <%= number_to_currency(@invoice.total_discount) %> <b id="total-discount">)</b></p>
+    <p>Total Revenue After Discounts: <%= number_to_currency(@invoice.total_discounted_revenue) %></p>
+  </div>
 
   <h4>Customer:</h4>
     <%= @customer.first_name %> <%= @customer.last_name %><br>

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe "invoices show" do
     @ii_8 = InvoiceItem.create!(invoice_id: @invoice_7.id, item_id: @item_8.id, quantity: 1, unit_price: 5, status: 1)
     @ii_9 = InvoiceItem.create!(invoice_id: @invoice_7.id, item_id: @item_4.id, quantity: 1, unit_price: 1, status: 1)
     @ii_10 = InvoiceItem.create!(invoice_id: @invoice_8.id, item_id: @item_5.id, quantity: 1, unit_price: 1, status: 1)
-    @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 12, unit_price: 6, status: 1)
+    @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 5, unit_price: 6, status: 1)
+    @ii_12 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_3.id, quantity: 3, unit_price: 9, status: 1)
 
     @transaction1 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_1.id)
     @transaction2 = Transaction.create!(credit_card_number: 230948, result: 1, invoice_id: @invoice_2.id)
@@ -51,27 +52,26 @@ RSpec.describe "invoices show" do
     @transaction6 = Transaction.create!(credit_card_number: 879799, result: 0, invoice_id: @invoice_6.id)
     @transaction7 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_7.id)
     @transaction8 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_8.id)
+    
+    @discount_1 = @merchant1.discounts.create!(percent_discount: 20, threshold_quantity: 8)
+    @discount_2 = @merchant1.discounts.create!(percent_discount: 10, threshold_quantity: 5)
+
+    visit merchant_invoice_path(@merchant1, @invoice_1)
   end
 
   it "shows the invoice information" do
-    visit merchant_invoice_path(@merchant1, @invoice_1)
-
     expect(page).to have_content(@invoice_1.id)
     expect(page).to have_content(@invoice_1.status)
     expect(page).to have_content(@invoice_1.created_at.strftime("%A, %B %-d, %Y"))
   end
 
   it "shows the customer information" do
-    visit merchant_invoice_path(@merchant1, @invoice_1)
-
     expect(page).to have_content(@customer_1.first_name)
     expect(page).to have_content(@customer_1.last_name)
     expect(page).to_not have_content(@customer_2.last_name)
   end
 
   it "shows the item information" do
-    visit merchant_invoice_path(@merchant1, @invoice_1)
-
     expect(page).to have_content(@item_1.name)
     expect(page).to have_content(@ii_1.quantity)
     expect(page).to have_content(@ii_1.unit_price)
@@ -80,14 +80,10 @@ RSpec.describe "invoices show" do
   end
 
   it "shows the total revenue for this invoice" do
-    visit merchant_invoice_path(@merchant1, @invoice_1)
-
     expect(page).to have_content(@invoice_1.total_revenue)
   end
 
   it "shows a select field to update the invoice status" do
-    visit merchant_invoice_path(@merchant1, @invoice_1)
-
     within("#the-status-#{@ii_1.id}") do
       page.select("cancelled")
       click_button "Update Invoice"
@@ -100,4 +96,15 @@ RSpec.describe "invoices show" do
     end
   end
 
+  it "shows the total discount for this invoice" do
+    within("#invoice-info") do
+      expect(page).to have_content(@invoice_1.total_discount)
+    end
+  end
+
+  it "shows the total discounted revenue (revenue after discounts)" do
+    within("#invoice-info") do
+      expect(page).to have_content(@invoice_1.total_discounted_revenue)
+    end
+  end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -5,23 +5,47 @@ RSpec.describe Invoice, type: :model do
     it { should validate_presence_of :status }
     it { should validate_presence_of :customer_id }
   end
+
   describe "relationships" do
     it { should belong_to :customer }
     it { should have_many(:items).through(:invoice_items) }
     it { should have_many(:merchants).through(:items) }
     it { should have_many :transactions}
+    it { should have_many(:discounts).through(:merchants)}
   end
+
   describe "instance methods" do
-    it "total_revenue" do
+    before :each do
       @merchant1 = Merchant.create!(name: 'Hair Care')
       @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
-      @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
+      @item_2 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 11, merchant_id: @merchant1.id)
+      @item_3 = Item.create!(name: "Cat Toy", description: "Has catnip in it", unit_price: 12, merchant_id: @merchant1.id)
       @customer_1 = Customer.create!(first_name: 'Joey', last_name: 'Smith')
       @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2, created_at: "2012-03-27 14:54:09")
       @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 9, unit_price: 10, status: 2)
-      @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 1, unit_price: 10, status: 1)
+      @ii_2 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_2.id, quantity: 1, unit_price: 10, status: 1)
+      @ii_3 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_3.id, quantity: 5, unit_price: 10, status: 1)
+      @discount_1 = @merchant1.discounts.create!(percent_discount: 20, threshold_quantity: 8)
+      @discount_2 = @merchant1.discounts.create!(percent_discount: 10, threshold_quantity: 5)
+    end
 
-      expect(@invoice_1.total_revenue).to eq(100)
+    it "#total_revenue" do
+      expect(@invoice_1.total_revenue).to eq(150)
+    end
+
+    it "#total_discount" do
+      first = @ii_1.quantity * @ii_1.unit_price * (@discount_1.percent_discount / 100.0)
+      third = @ii_3.quantity * @ii_3.unit_price * (@discount_2.percent_discount / 100.0)
+      expected = first + third
+
+      expect(@invoice_1.total_discount).to eq(expected) #23
+    end
+
+    it "#total_discounted_revenue" do
+      first = @ii_1.quantity * @ii_1.unit_price * (@discount_1.percent_discount / 100.0)
+      third = @ii_3.quantity * @ii_3.unit_price * (@discount_2.percent_discount / 100.0)
+      expected = @invoice_1.total_revenue - first - third
+      expect(@invoice_1.total_discounted_revenue).to eq(expected) #127
     end
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -33,19 +33,37 @@ RSpec.describe Invoice, type: :model do
       expect(@invoice_1.total_revenue).to eq(150)
     end
 
-    it "#total_discount" do
-      first = @ii_1.quantity * @ii_1.unit_price * (@discount_1.percent_discount / 100.0)
-      third = @ii_3.quantity * @ii_3.unit_price * (@discount_2.percent_discount / 100.0)
-      expected = first + third
+    describe "Discounts and its Conditions" do
+      it "only applies greatest discount when item meets threshold for multiple discounts" do
+        @ii_2.destroy
+        @ii_3.destroy    
+        expect(@invoice_1.invoice_items).to eq([@ii_1])
+    
+        expect(@invoice_1.total_discount).to eq(18) #invoice item #1 meets boths discount thresholds (5 and 8), so only 20% should be applied
+      end
+      
+      it "only applies the discount to the invoice item(s) that meets the threshold(s)" do
+        @ii_3.destroy
+        expect(@invoice_1.invoice_items).to eq([@ii_1, @ii_2])
 
-      expect(@invoice_1.total_discount).to eq(expected) #23
-    end
+        expect(@invoice_1.total_discount).to eq(18) #invoice item # 2 does not meet any of the discount thresholds
+      end
 
-    it "#total_discounted_revenue" do
-      first = @ii_1.quantity * @ii_1.unit_price * (@discount_1.percent_discount / 100.0)
-      third = @ii_3.quantity * @ii_3.unit_price * (@discount_2.percent_discount / 100.0)
-      expected = @invoice_1.total_revenue - first - third
-      expect(@invoice_1.total_discounted_revenue).to eq(expected) #127
+      it "#total_discount" do
+        first = @ii_1.quantity * @ii_1.unit_price * (@discount_1.percent_discount / 100.0)
+        third = @ii_3.quantity * @ii_3.unit_price * (@discount_2.percent_discount / 100.0)
+        expected = first + third
+
+        expect(@invoice_1.total_discount).to eq(expected) #23
+      end
+
+      it "#total_discounted_revenue" do
+        first = @ii_1.quantity * @ii_1.unit_price * (@discount_1.percent_discount / 100.0)
+        third = @ii_3.quantity * @ii_3.unit_price * (@discount_2.percent_discount / 100.0)
+        expected = @invoice_1.total_revenue - first - third
+        
+        expect(@invoice_1.total_discounted_revenue).to eq(expected) #127
+      end      
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Item, type: :model do
   describe "relationships" do
     it { should have_many(:invoices).through(:invoice_items) }
     it { should belong_to :merchant }
+    it { should have_many(:discounts).through(:merchant) }
   end
   describe "instance methods" do
     it "best day" do


### PR DESCRIPTION
### Describe the changes:
- Adds discounts association to Item Model
- Adds #total_discount and #total_discounted_revenue methods to Invoice model, and relevant tests
- Adds tests, and views for using these on the Merchant Invoice Show pages

### Relevant User Story
```
6: Merchant Invoice Show Page: Total Revenue and Discounted Revenue

As a merchant
When I visit my merchant invoice show page
Then I see the total revenue for my merchant from this invoice (not including discounts)
And I see the total discounted revenue for my merchant from this invoice which includes bulk discounts in the calculation
### Test Coverage
```
-[100.0%] SimpleCov Test Coverage