### PR TITLE
7 link to applied discounts

### DIFF
--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -6,12 +6,25 @@ class InvoiceItem < ApplicationRecord
                         :status
 
   belongs_to :invoice
-  belongs_to :item
-
+  belongs_to :item 
   enum status: [:pending, :packaged, :shipped]
 
   def self.incomplete_invoices
     invoice_ids = InvoiceItem.where("status = 0 OR status = 1").pluck(:invoice_id)
     Invoice.order(created_at: :asc).find(invoice_ids)
+  end
+
+  def find_max_percent
+    ii = InvoiceItem
+      .joins(item: { merchant: :discounts })
+      .select("MAX(discounts.percent_discount) as max_percent")
+      .where("discounts.threshold_quantity <= invoice_items.quantity")
+      .find_by(id: self.id)
+
+    ii.max_percent
+  end
+
+  def discount_applied
+    item.discounts.find_by(percent_discount: find_max_percent)
   end
 end

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -23,11 +23,14 @@
   <br>
   <h4>Items on this Invoice:</h4>
   <table class="table">
+
+
     <thead>
       <tr class="tr">
         <th class="th1">Item Name</th>
         <th class="th1">Quantity</th>
         <th class="th1">Unit Price</th>
+        <th class="th1">Discount Applied</th>
         <th class="th1">Status</th>
       </tr>
     </thead>
@@ -39,12 +42,17 @@
             <td style="text-align:center"><%= i.item.name %></td>
             <td style="text-align:center"><%= i.quantity %></td>
             <td style="text-align:center">$<%= i.unit_price %></td>
+            <% if i.discount_applied.nil? %>
+              <td style="text-align:center"> - </td>
+            <% else %>
+              <td style="text-align:center"><%= link_to "#{i.discount_applied.percent_discount}%", merchant_discount_path(@merchant, i.discount_applied.id) %></td>
+            <% end %>
             <td style="text-align:center">
               <%= form_with model: @invoice, url: merchant_invoice_path(@merchant, @invoice), method: :patch, local: true do |f| %>
                 <%= f.select :status, Invoice.statuses.keys, selected: "#{@invoice.status}" %>
                 <%= f.submit 'Update Invoice' %>
               <% end %>
-              </td>
+            </td>
           </tr>
         </section>
       <% end %>

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -64,7 +64,23 @@ RSpec.describe "invoices show" do
     expect(page).to have_content(@invoice_1.status)
     expect(page).to have_content(@invoice_1.created_at.strftime("%A, %B %-d, %Y"))
   end
-
+  
+  it "shows the total revenue for this invoice" do
+    expect(page).to have_content(@invoice_1.total_revenue)
+  end
+  
+  it "shows the total discount for this invoice" do
+    within("#invoice-info") do
+      expect(page).to have_content(@invoice_1.total_discount)
+    end
+  end
+  
+  it "shows the total discounted revenue (revenue after discounts)" do
+    within("#invoice-info") do
+      expect(page).to have_content(@invoice_1.total_discounted_revenue)
+    end
+  end
+  
   it "shows the customer information" do
     expect(page).to have_content(@customer_1.first_name)
     expect(page).to have_content(@customer_1.last_name)
@@ -76,12 +92,19 @@ RSpec.describe "invoices show" do
     expect(page).to have_content(@ii_1.quantity)
     expect(page).to have_content(@ii_1.unit_price)
     expect(page).to_not have_content(@ii_4.unit_price)
-
   end
 
-  it "shows the total revenue for this invoice" do
-    expect(page).to have_content(@invoice_1.total_revenue)
+  it "shows the discount applied to each item and links to discount's show page" do
+    expect(page).to have_link("#{@ii_1.discount_applied.percent_discount}%")
+    expect(page).to have_link("#{@ii_11.discount_applied.percent_discount}%")
   end
+
+  it "shows a dash if the item has no discount applied" do
+    within("#the-status-#{@ii_12.id}") do
+      expect(page).to have_content("-")
+    end
+  end
+
 
   it "shows a select field to update the invoice status" do
     within("#the-status-#{@ii_1.id}") do
@@ -93,18 +116,6 @@ RSpec.describe "invoices show" do
 
     within("#current-invoice-status") do
       expect(page).to_not have_content("in progress")
-    end
-  end
-
-  it "shows the total discount for this invoice" do
-    within("#invoice-info") do
-      expect(page).to have_content(@invoice_1.total_discount)
-    end
-  end
-
-  it "shows the total discounted revenue (revenue after discounts)" do
-    within("#invoice-info") do
-      expect(page).to have_content(@invoice_1.total_discounted_revenue)
     end
   end
 end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -57,15 +57,15 @@ RSpec.describe InvoiceItem, type: :model do
     end
 
     it "Finds the max percent discount for an invoice item" do
-      expect(@ii_1.discount_applied.find_max_percent).to eq(@discount_1.percent_discount)
-      expect(@ii_2.discount_applied.find_max_percent).to eq(@discount_2.percent_discount)
-      expect(@ii_3.discount_applied.find_max_percent).to eq(nil)
+      expect(@ii_1.find_max_percent).to eq(@discount_1.percent_discount)
+      expect(@ii_2.find_max_percent).to eq(@discount_2.percent_discount)
+      expect(@ii_3.find_max_percent).to eq(nil)
     end
 
     it "finds invoice item's #discount_applied" do
-      expect(@ii_1.discount_applied.discount_id).to eq(@discount_1.id)
-      expect(@ii_2.discount_applied.discount_id).to eq(@discount_2.id)
-      expect(@ii_3.discount_applied&.discount_id).to eq(nil) # does not meet quantity threshold
+      expect(@ii_1.discount_applied.id).to eq(@discount_1.id)
+      expect(@ii_2.discount_applied.id).to eq(@discount_2.id)
+      expect(@ii_3.discount_applied&.id).to eq(nil) # does not meet quantity threshold
     end
   end
 end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -35,8 +35,37 @@ RSpec.describe InvoiceItem, type: :model do
       @ii_3 = InvoiceItem.create!(invoice_id: @i2.id, item_id: @item_3.id, quantity: 1, unit_price: 5, status: 2)
       @ii_4 = InvoiceItem.create!(invoice_id: @i3.id, item_id: @item_3.id, quantity: 1, unit_price: 5, status: 1)
     end
-    it 'incomplete_invoices' do
+
+    it '#self.incomplete_invoices' do
       expect(InvoiceItem.incomplete_invoices).to eq([@i1, @i3])
+    end
+  end
+
+  describe "Instance Methods" do
+    before(:each) do
+      @merchant_1 = Merchant.create!(name: 'Merchant 1')
+      @customer_1 = Customer.create!(first_name: 'Bilbo', last_name: 'Baggins')
+      @item_1 = Item.create!(name: 'Shampoo', description: 'This washes your hair', unit_price: 10, merchant_id: @merchant_1.id)
+      @item_2 = Item.create!(name: 'Conditioner', description: 'This makes your hair shiny', unit_price: 8, merchant_id: @merchant_1.id)
+      @item_3 = Item.create!(name: 'Brush', description: 'This takes out tangles', unit_price: 5, merchant_id: @merchant_1.id)
+      @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2)
+      @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 9, unit_price: 10, status: 0)
+      @ii_2 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_2.id, quantity: 5, unit_price: 8, status: 0)
+      @ii_3 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_3.id, quantity: 3, unit_price: 8, status: 0)
+      @discount_1 = @merchant_1.discounts.create!(percent_discount: 20, threshold_quantity: 8)
+      @discount_2 = @merchant_1.discounts.create!(percent_discount: 10, threshold_quantity: 5)
+    end
+
+    it "Finds the max percent discount for an invoice item" do
+      expect(@ii_1.discount_applied.find_max_percent).to eq(@discount_1.percent_discount)
+      expect(@ii_2.discount_applied.find_max_percent).to eq(@discount_2.percent_discount)
+      expect(@ii_3.discount_applied.find_max_percent).to eq(nil)
+    end
+
+    it "finds invoice item's #discount_applied" do
+      expect(@ii_1.discount_applied.discount_id).to eq(@discount_1.id)
+      expect(@ii_2.discount_applied.discount_id).to eq(@discount_2.id)
+      expect(@ii_3.discount_applied&.discount_id).to eq(nil) # does not meet quantity threshold
     end
   end
 end


### PR DESCRIPTION
### Describe the changes:
- Adds #find_max_percent and #discount_applied instance methods to InvoiceItem model, with relevant tests
- Adds tests and view for listing the discount percent and link to relevant discount show page for each invoice item
### Relevant User Story
```
7: Merchant Invoice Show Page: Link to applied discounts

As a merchant
When I visit my merchant invoice show page
Next to each invoice item I see a link to the show page for the bulk discount that was applied (if any)
```
### Test Coverage
-[100.0%] SimpleCov Test Coverage