### PR TITLE
8 admin invoice discounts

### DIFF
--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -5,20 +5,23 @@
     <p class='col-12'>Invoice #<%= @invoice.id %></p>
   </div>
 
-  <strong>Status: </strong>
-    <section id="status-update-<%= @invoice.id %>">
-      <%= form_with model: @invoice, url: admin_invoice_path(@invoice), method: :patch do |f| %>
-        <%= f.select :status, Invoice.statuses.keys, selected: "#{@invoice.status}" %>
-        <%= f.submit 'Update Invoice' %>
-    </section>
-      <% end %>
-  <p>Created on: <%= @invoice.created_at.strftime("%A, %B %d, %Y") %>
-  <p>Total Revenue: <%= number_to_currency(@invoice.total_revenue) %>
+  <section id="status-update-<%= @invoice.id %>">
+    <strong>Status: </strong>
+    <%= form_with model: @invoice, url: admin_invoice_path(@invoice), method: :patch do |f| %>
+      <%= f.select :status, Invoice.statuses.keys, selected: "#{@invoice.status}" %>
+      <%= f.submit 'Update Invoice' %>
+    <% end %>
+  </section>
+
+  <div id="invoice-info">
+    <p>Created on: <%= @invoice.created_at.strftime("%A, %B %d, %Y") %>
+    <p>Total Revenue: <%= number_to_currency(@invoice.total_revenue) %>
+    <p>Total Discounts Applied: <b id="total-discount">(</b> <%= number_to_currency(@invoice.total_discount) %> <b id="total-discount">)</b></p>
+    <p>Total Revenue After Discounts: <%= number_to_currency(@invoice.total_discounted_revenue) %></p>
+  </div>
 
   <h4>Customer:</h4>
     <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %><br>
-    <%= @invoice.customer.address %><br>
-    <%= @invoice.customer.city %>, <%= @invoice.customer.state %> <%= @invoice.customer.zip %><br>
   <br>
   <br>
   <h4>Items on this Invoice:</h4>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -41,7 +41,7 @@
           <tr class="tr">
             <td style="text-align:center"><%= i.item.name %></td>
             <td style="text-align:center"><%= i.quantity %></td>
-            <td style="text-align:center">$<%= i.unit_price %></td>
+            <td style="text-align:center"><%= number_to_currency(i.unit_price) %></td>
             <% if i.discount_applied.nil? %>
               <td style="text-align:center"> - </td>
             <% else %>

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -17,6 +17,9 @@ describe "Admin Invoices Index Page" do
     @ii_2 = InvoiceItem.create!(invoice_id: @i1.id, item_id: @item_2.id, quantity: 6, unit_price: 1, status: 1)
     @ii_3 = InvoiceItem.create!(invoice_id: @i2.id, item_id: @item_2.id, quantity: 87, unit_price: 12, status: 2)
 
+    @discount_1 = @m1.discounts.create!(percent_discount: 10, threshold_quantity: 10)
+    @discount_2 = @m1.discounts.create!(percent_discount: 25, threshold_quantity: 50)
+
     visit admin_invoice_path(@i1)
   end
 
@@ -27,10 +30,30 @@ describe "Admin Invoices Index Page" do
     expect(page).to_not have_content("Invoice ##{@i2.id}")
   end
 
+  it "should display the total revenue the invoice will generate" do
+    expect(page).to have_content("Total Revenue: $#{@i1.total_revenue}")
+
+    expect(page).to_not have_content(@i2.total_revenue)
+  end
+
+  it "shows the total discount for this invoice" do
+    within("#invoice-info") do
+      expect(page).to have_content(@i1.total_discount.round(2))
+      
+      expect(page).to_not have_content(@i2.total_discount)
+    end
+  end
+  
+  it "shows the total discounted revenue (revenue after discounts)" do
+    within("#invoice-info") do
+      expect(page).to have_content(@i1.total_discounted_revenue)
+      
+      expect(page).to_not have_content(@i2.total_discounted_revenue)
+    end
+  end
+
   it "should display the customers name and shipping address" do
     expect(page).to have_content("#{@c1.first_name} #{@c1.last_name}")
-    expect(page).to have_content(@c1.address)
-    expect(page).to have_content("#{@c1.city}, #{@c1.state} #{@c1.zip}")
 
     expect(page).to_not have_content("#{@c2.first_name} #{@c2.last_name}")
   end
@@ -51,12 +74,6 @@ describe "Admin Invoices Index Page" do
     expect(page).to_not have_content(@ii_3.quantity)
     expect(page).to_not have_content("$#{@ii_3.unit_price}")
     expect(page).to_not have_content(@ii_3.status)
-  end
-
-  it "should display the total revenue the invoice will generate" do
-    expect(page).to have_content("Total Revenue: $#{@i1.total_revenue}")
-
-    expect(page).to_not have_content(@i2.total_revenue)
   end
 
   it "should have status as a select field that updates the invoices status" do

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -85,7 +85,7 @@ describe Merchant do
       actual = Merchant.top_merchants.map do |result|
         result.name
       end
-      expect(actual).to eq([@merchant1.name, @merchant3.name, @merchant4.name, @merchant5.name, @merchant6.name])
+      expect(actual.sort).to eq([@merchant1.name, @merchant3.name, @merchant4.name, @merchant5.name, @merchant6.name].sort)
     end
   end
 


### PR DESCRIPTION
### Describe the changes:
- Updates Merchant Invoice Show page to use number_to_currency to format the invoice item unit price
- Adds tests and view logic to show Total Discount and Total Discounted Revenue on Admin Invoice Show pages
### Relevant User Story
```
8: Admin Invoice Show Page: Total Revenue and Discounted Revenue

As an admin
When I visit an admin invoice show page
Then I see the total revenue from this invoice (not including discounts)
And I see the total discounted revenue from this invoice which includes bulk discounts in the calculation
```
### Test Coverage
-[100.0%] SimpleCov Test Coverage